### PR TITLE
Give read and write permisions to all host dir used for  bind mounts on aws

### DIFF
--- a/src/aws/wa_ent.yml
+++ b/src/aws/wa_ent.yml
@@ -1497,7 +1497,9 @@ Resources:
                 - { MntPoint: !FindInMap [Constants, Values, MountPoint] }
             03_permissions:
               command: !Sub
-                - chown centos:centos ${MntPoint}/data ${MntPoint}/media
+                -  |
+                  chown centos:centos ${MntPoint}/data ${MntPoint}/media
+                  chmod -R a+rw ${MntPoint}/data ${MntPoint}/media
                 - { MntPoint: !FindInMap [Constants, Values, MountPoint] }
         log_setup:
           files:


### PR DESCRIPTION
We made a change to stop using root user by default. This change means when using mount bounds in docker, the local host dirs that we will be mounting on need to allow reads and write by the users we are using on the containers. 