### PR TITLE
[AWS] Update DB connection certificate url

### DIFF
--- a/src/aws/wa_ent.yml
+++ b/src/aws/wa_ent.yml
@@ -246,7 +246,7 @@ Parameters:
     AllowedValues: [enabled, disabled]
   DBConnCA:
     Description: CA to verify database connection
-    Default: https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
+    Default: https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
     Type: String
   DBConnCert:
     Description: Client certificate for database connection


### PR DESCRIPTION
The DBConnCA certificate at the existing url expired back in 2022 but AWS RDS encrypted connection was still working somehow.
Recently, newly created stack web instance started getting DB connection error due to expired db-ca.pem certificate.
Updating DBConnCA url that is used to download latest db-ca.pem file. This file contains CA certificate for DB connection.